### PR TITLE
setOptions uses forceUpdate so initialization is sync

### DIFF
--- a/src/__snapshots__/index.test.js.snap
+++ b/src/__snapshots__/index.test.js.snap
@@ -19,6 +19,21 @@ Object {
     },
     "orderedModifiers": Array [],
     "placement": "bottom",
+    "rects": Object {
+      "popper": Object {
+        "height": 0,
+        "width": 0,
+        "x": 0,
+        "y": 0,
+      },
+      "reference": Object {
+        "height": 0,
+        "width": 0,
+        "x": 0,
+        "y": 0,
+      },
+    },
+    "reset": false,
     "scrollParents": Object {
       "popper": Array [
         [Window],

--- a/src/index.js
+++ b/src/index.js
@@ -155,7 +155,10 @@ export function popperGenerator(generatorOptions: PopperGeneratorArgs = {}) {
 
         runModifierEffects();
 
-        return instance.update();
+        instance.forceUpdate();
+        // @deprecated, the promise return type is for api compatibility and
+        // will be removed in the future
+        return Promise.resolve(state);
       },
 
       // Sync update – it will always be executed, even if not necessary. This
@@ -164,6 +167,8 @@ export function popperGenerator(generatorOptions: PopperGeneratorArgs = {}) {
       // For high frequency updates (e.g. `resize` and `scroll` events), always
       // prefer the async Popper#update method
       forceUpdate() {
+        instance.update.cancel();
+
         if (isDestroyed) {
           return;
         }
@@ -256,11 +261,10 @@ export function popperGenerator(generatorOptions: PopperGeneratorArgs = {}) {
       return instance;
     }
 
-    instance.setOptions(options).then(state => {
-      if (!isDestroyed && options.onFirstUpdate) {
-        options.onFirstUpdate(state);
-      }
-    });
+    instance.setOptions(options);
+    if (options.onFirstUpdate) {
+      options.onFirstUpdate(state);
+    }
 
     // Modifiers have the ability to execute arbitrary code before the first
     // update cycle runs. They will be executed in the same order as the update

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -195,17 +195,4 @@ describe('.destroy() method', () => {
 
     expect(spy).toHaveBeenCalledTimes(1);
   });
-
-  it('forceUpdate() is not ran when destroy is called sync', done => {
-    const spy = jest.fn();
-
-    createPopper(reference, getPopper(), {
-      modifiers: [{ ...testModifier, fn: spy }],
-    }).destroy();
-
-    setTimeout(() => {
-      expect(spy).not.toHaveBeenCalled();
-      done();
-    });
-  });
 });

--- a/src/utils/debounce.js
+++ b/src/utils/debounce.js
@@ -1,17 +1,29 @@
 // @flow
 
-export default function debounce<T>(fn: Function): () => Promise<T> {
+type Debounce<T> = {
+  (): Promise<T>,
+  cancel(): void,
+};
+
+export default function debounce<T>(fn: () => Promise<T> | T): Debounce<T> {
   let pending;
-  return () => {
+
+  const callback: Debounce = function() {
     if (!pending) {
       pending = new Promise<T>(resolve => {
         Promise.resolve().then(() => {
-          pending = undefined;
-          resolve(fn());
+          if (pending) {
+            pending = undefined;
+            resolve(fn());
+          }
         });
       });
     }
 
     return pending;
   };
+
+  callback.cancel = () => (pending = undefined);
+
+  return callback;
 }


### PR DESCRIPTION
This PR changes the initialization to run sync via forceUpdate rather than async with update which causes problems in test suites as the promise is not returned. This has a change in behaviour as setOptions update is not debounced although this seems fine to me as you should not be calling setOptions repeatedly. The return type of setOptions is still a promise, but this should be removed in the future. This would also change the behaviour, even remove the need of onFirstUpdate.
I've also added a cancel method to the debounced update function, currently if you had called update and then forceUpdate it would run forceUpdate twice, which shouldn't be needed.